### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/build-and-push-dev.yaml
+++ b/.github/workflows/build-and-push-dev.yaml
@@ -28,9 +28,9 @@ jobs:
     steps:
       - id: main
         run: |
-          echo ::set-output name=version::$(echo ${GITHUB_SHA} | cut -c1-7)
-          echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
-          echo ::set-output name=repository::$GITHUB_REPOSITORY
+          echo version=$(echo ${GITHUB_SHA} | cut -c1-7) >> "$GITHUB_OUTPUT"
+          echo created=$(date -u +'%Y-%m-%dT%H:%M:%SZ') >> "$GITHUB_OUTPUT"
+          echo repository=$GITHUB_REPOSITORY >> "$GITHUB_OUTPUT"
 
   package-services:
     runs-on: ubuntu-latest
@@ -92,7 +92,7 @@ jobs:
       - name: Output image tag
         id: image-tag
         run: |
-          echo ::set-output name=image-${{ matrix.services.appName }}::${{ env.REGISTRY }}/$GITHUB_REPOSITORY/${{ matrix.services.appName }}:sha-${{ needs.set-env.outputs.version }} | tr '[:upper:]' '[:lower:]'
+          echo image-${{ matrix.services.appName }}=${{ env.REGISTRY }}/$GITHUB_REPOSITORY/${{ matrix.services.appName }}:sha-${{ needs.set-env.outputs.version }} | tr '[:upper:]' '[:lower:]' >> "$GITHUB_OUTPUT"
 
   deploy:
     if: github.repository != 'Azure-samples/containerapps-dapralbums'

--- a/.github/workflows/build-and-push-prod.yaml
+++ b/.github/workflows/build-and-push-prod.yaml
@@ -28,9 +28,9 @@ jobs:
     steps:
       - id: main
         run: |
-          echo ::set-output name=version::$(echo ${GITHUB_SHA} | cut -c1-7)
-          echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
-          echo ::set-output name=repository::$GITHUB_REPOSITORY
+          echo version=$(echo ${GITHUB_SHA} | cut -c1-7) >> "$GITHUB_OUTPUT"
+          echo created=$(date -u +'%Y-%m-%dT%H:%M:%SZ') >> "$GITHUB_OUTPUT"
+          echo repository=$GITHUB_REPOSITORY >> "$GITHUB_OUTPUT"
 
   package-services:
     runs-on: ubuntu-latest
@@ -92,7 +92,7 @@ jobs:
       - name: Output image tag
         id: image-tag
         run: |
-          echo ::set-output name=image-${{ matrix.services.appName }}::${{ env.REGISTRY }}/$GITHUB_REPOSITORY/${{ matrix.services.appName }}:sha-${{ needs.set-env.outputs.version }} | tr '[:upper:]' '[:lower:]'
+          echo image-${{ matrix.services.appName }}=${{ env.REGISTRY }}/$GITHUB_REPOSITORY/${{ matrix.services.appName }}:sha-${{ needs.set-env.outputs.version }} | tr '[:upper:]' '[:lower:]' >> "$GITHUB_OUTPUT"
 
   deploy:
     if: github.repository != 'Azure-samples/containerapps-dapralbums'


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `::set-output` to `"$GITHUB_OUTPUT"`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter